### PR TITLE
docs: A3 마일스톤 조건 재정의안 작성

### DIFF
--- a/docs/26_MILESTONE_CONDITION_ALIGNMENT_V1.md
+++ b/docs/26_MILESTONE_CONDITION_ALIGNMENT_V1.md
@@ -21,6 +21,14 @@
 | `streak-7` | `streakDays >= 7` | streak 7일 달성 시 노출 | "7일 스트릭 달성" |
 | `final-complete` | `track-a-complete && track-b-complete && track-c-complete` | 전체 트랙 100% 시 노출 | "전체 커리큘럼 완료" |
 
+### first-chapter 기준 고정(현재 버전)
+
+| 기준 | 값 |
+| --- | --- |
+| chapterSlug | `tmux-onramp` |
+| chapter order (Track A) | `0` |
+| 포함 missionSlug | `hello-tmux-version-check` |
+
 ## 3) 문구-조건 매핑표
 
 | 마일스톤 | 기존 문구 리스크 | v1 문구/설명 가이드 |


### PR DESCRIPTION
## 요약
- 마일스톤 조건 정의표와 문구-조건 매핑표를 문서화했습니다.
- `first-chapter-complete`를 첫 챕터 전체 완료 기준으로 엄격화하는 규칙을 명시했습니다.
- Progress/Share 노출 규칙과 #11 구현 체크리스트를 추가했습니다.

## UX 관점
- 사용자가 보는 문구와 실제 조건식을 일치시켜 해금 이유를 설명 가능하게 했습니다.
- Progress와 Share가 같은 slug 계약을 사용하도록 기준을 고정했습니다.

## 테스트
- 문서 작업으로 코드 테스트는 실행하지 않았습니다.

Closes #5